### PR TITLE
rename classtool -> classy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Classtool
-=========
+Classy
+======
 
 This is a simple tool to enable class like idioms in JavaScript.  It is notably different
 from traditional class based inheritance in the following ways:
@@ -31,7 +31,7 @@ The following is an example class definition:
     };
     module.defineClass(ClassSpec); 
 
-To use classtool, simply require it at the beginning of your program:
+To use classy, simply require it at the beginning of your program:
 
     require('classtool');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "classtool",
-  "description" : "Class like behavior composition, but better",
+  "description" : "Classy: class like behavior composition, but better",
   "version" : "1.0.0",
   "author" : "Stephen Pair <stephen@bitpay.com>",
   "main" : "./index",
@@ -10,7 +10,7 @@
   ],
   "repository" : {
     "type" : "git",
-    "url" : "http://github.com/gasteve/classtool.git"
+    "url" : "https://github.com/bitpay/classy"
   },
   "scripts" : {},
   "devDependencies" : {},


### PR DESCRIPTION
...leave the npm package "classtool" both for backwards-compatibility and
because the npm name "classy" is taken by someone else (for something
unrelated).
